### PR TITLE
Fix using depreciated functions

### DIFF
--- a/CRM/Overrides/Page/Overrides.php
+++ b/CRM/Overrides/Page/Overrides.php
@@ -48,7 +48,7 @@ class CRM_Overrides_Page_Overrides extends CRM_Core_Page {
     $this->assign('friendly', $friendly);
     $this->assign('core', $this->core);
     $this->assign('snapshot', $snapshot);
-    $this->assign('last_snapshot', CRM_Core_BAO_Setting::getItem('com.klangsoft_overrides', 'last_snapshot'));
+    $this->assign('last_snapshot', \Civi::settings()->get('com.klangsoft_overrides:last_snapshot'));
 
     parent::run();
   }

--- a/overrides.php
+++ b/overrides.php
@@ -37,7 +37,7 @@ function overrides_civicrm_install() {
 
   CRM_Core_DAO::executeQuery("INSERT INTO `klangsoft_overrides` VALUES ('a:0:{}');");
 
-  CRM_Core_BAO_Setting::setItem('', 'com.klangsoft_overrides', 'last_snapshot');
+  \Civi::settings()->set('com.klangsoft_overrides:last_snapshot', '');
 
   _overrides_civix_civicrm_install();
 }


### PR DESCRIPTION
CiviCRM changed the way they handle warning for using a deprecated function.  See this [PR ](https://github.com/civicrm/civicrm-core/pull/19256).

The changed will always throw use deprecated warning if the deprecated function is used in anywhere, for example, Drupal module, CiviCRM extension. This would not have an issue we install the extension / module via user interface. However, when we use Drush site-install command to install the Drupal site that ship with a Drupal profile that install the extension when creating a site.

Any module or extension that use CiviCRM's deprecated function in the installation hook, upgrade hook, the E_USER_DEPRECATED warning will throw during installation, but Drush handles deprecated messages as an error rather than a warning.

This PR migrating deprecated functions which are   CRM_Core_BAO_Setting::getItem() and  CRM_Core_BAO_Setting::setItem() to use Civi::settings() as per CiviCRM recommendation. 